### PR TITLE
refactor: 기본값 정리 및 Jenkins 모드 제한

### DIFF
--- a/src/tools/cron-generator.tsx
+++ b/src/tools/cron-generator.tsx
@@ -100,7 +100,7 @@ function makeFields(platform: CronPlatform, overrides: Partial<Record<FieldKey, 
   // 나머지 키 기본값 채우기
   for (const key of ["second", "minute", "hour", "day", "month", "weekday", "year"] as FieldKey[]) {
     if (!result[key]) {
-      result[key] = defaultField(ALL_FIELD_DEFS[key]);
+      result[key] = defaultField(ALL_FIELD_DEFS[key]!);
     }
   }
   return result;


### PR DESCRIPTION
## 📝 작업 내용

- 누락 필드 기본 값 통일
- Field Breakdown 연산 중복 제거
- 설명 분기 단순화
- 젠킨스는 H 만 허용되게 수정


## 🔗 관련 이슈

- Closes #



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# 코드 리뷰: cron-generator 리팩토링

## 📋 고수준 검토 의견

이 PR은 **기본값 관리의 일관성 개선**, **코드 중복 제거**, **Field Breakdown 성능 최적화**라는 목표를 대체로 잘 달성했습니다. 구현 방식은 안전하며, `useMemo`와 배열 불변성 원칙을 올바르게 적용했습니다. 다만 다음의 **아키텍처 및 정책 일관성** 관련 개선 사항을 권장합니다.

---

## 🔴 중대 이슈

### Jenkins 정책 설명 vs 실제 구현 불일치

**현재 상황:**
- PR 설명: "젠킨스는 H만 허용되게 수정"
- 코드 검증 로직(라인 ~359-369): 단일 숫자(예: `5`)는 거부하지만, **범위 표현(예: `1-5`)은 허용**

```javascript
// 라인 364-369: 범위는 명시적으로 허용 중
if (/^\d+-\d+$/.test(part)) {
  const [start, end] = part.split("-").map(Number);
  // 범위 검증만 수행, 에러 반환 안 함
  continue;
}

// 라인 372: 일반 숫자만 에러 처리
errors.push(`${label}: '${part}' — Jenkins에서는 H 기반 표현식을 사용하세요.`);
```

**권장 조치:**

A) **현재 코드 동작에 맞춰 PR 설명 수정** (더 현실적):
```
기존: "젠킨스는 H만 허용되게 수정"
변경: "Jenkins에서 단일 숫자는 H 표현식으로 제한하고, H, H/n, H(n-m) 및 범위 표현(1-5 등)만 허용"
```

B) **또는 코드를 정책에 맞춰 범위도 제한** (더 엄격):
```javascript
// 라인 362-369에 추가
if (/^H\(.*\)/.test(part)) {
  // H(n-m) 또는 H(n-m)/s만 허용
  continue;
}

// Jenkins에서 일반 범위(n-m)는 H 기반이어야 함
if (/^\d+-\d+$/.test(part)) {
  errors.push(`${label}: '${part}' — Jenkins에서 범위는 H(n-m) 형식을 사용하세요.`);
  continue;
}
```

---

## ⚠️ 실제 동작 검증 필요

### 53~76번 라인: ALL_FIELD_DEFS 생성의 암묵적 가정

현재 코드:
```javascript
const ALL_FIELD_DEFS: Record<FieldKey, FieldDef> = [
  SECOND_DEF,
  ...COMMON_FIELDS,
  YEAR_DEF,
].reduce((acc, def) => {
  acc[def.key] = def;
  return acc;
}, {} as Record<FieldKey, FieldDef>);
```

**잠재적 위험:**
- `COMMON_FIELDS` 배열의 순서가 변경되거나 요소가 누락되면 런타임 에러 발생
- `FieldKey` 타입(`"second" | "minute" | "hour" | "day" | "month" | "weekday" | "year"`)과 실제 요소 간 불일치 미검증

**제안:**

```javascript
// 방법 1: 빌드 타임 검증 추가
const ALL_FIELD_DEFS: Record<FieldKey, FieldDef> = [
  SECOND_DEF,
  ...COMMON_FIELDS,
  YEAR_DEF,
].reduce((acc, def) => {
  acc[def.key] = def;
  return acc;
}, {} as Record<FieldKey, FieldDef>);

// 타입 안전성 검증 (TypeScript 4.4+)
const _: Record<FieldKey, FieldDef> = ALL_FIELD_DEFS;
```

또는 `makeFields` 라인 104-105에서 좀 더 방어적 처리:

```javascript
// 나머지 키 기본값 채우기
for (const key of ["second", "minute", "hour", "day", "month", "weekday", "year"] as FieldKey[]) {
  if (!result[key]) {
    if (!ALL_FIELD_DEFS[key]) {
      console.warn(`경고: ALL_FIELD_DEFS에 정의되지 않은 필드 '${key}'`);
    }
    result[key] = defaultField(ALL_FIELD_DEFS[key]!);
  }
}
```

---

## 💡 유지보수성 및 가독성 개선

### 1. parseField 중복 로직 통합 (라인 ~400-450)

**현재:** `parseField` 함수가 `getNextExecutions` 내부에만 정의되어 `validateExpression`과 중복된 정규식 검증 로직 포함

**제안:** `parseField`를 모듈 수준 함수로 추출

```javascript
/**
 * Cron 필드 표현식을 숫자 배열로 파싱
 * @returns null이면 모든 범위 값, 배열이면 해당 값들만 매칭
 */
function parseField(part: string, def: FieldDef): number[] | null {
  if (part === "*" || part === "?") return null;

  // 기존 parseField 로직...
  if (/^\*\/(\d+)$/.test(part)) {
    const step = parseInt(part.split("/")[1]);
    const vals: number[] = [];
    for (let i = def.min; i <= def.max; i += step) vals.push(i);
    return vals;
  }
  // ... 이하 기존 코드
}

function getNextExecutions(expr: string, platform: CronPlatform, count: number, hashSeed?: number): Date[] {
  const defs = FIELD_DEFS[platform];
  const resolvedExpr = platform === "jenkins" && hashSeed !== undefined
    ? resolveJenkinsH(expr, hashSeed, defs)
    : expr;

  const parts = resolvedExpr.trim().split(/\s+/).filter(Boolean);
  if (parts.length !== defs.length) return [];

  const fieldMap: Partial<Record<FieldKey, number[] | null>> = {};
  for (let i = 0; i < defs.length; i++) {
    fieldMap[defs[i].key] = parseField(parts[i], defs[i]);  // 재사용
  }
  // ...
}
```

### 2. validateExpression의 Jenkins 분기 응축 (라인 ~330-380)

현재 코드는 Jenkins 특정 검증과 일반 검증 로직이 섞여 있어 가독성이 떨어집니다.

```javascript
// 제안: 검증 로직을 platform별 헬퍼 함수로 분리
function validateJenkinsField(part: string, def: FieldDef): string[] {
  const errors: string[] = [];
  const label = def.label.split(" (")[0];

  if (part === "H") return errors;
  
  const hInterval = part.match(/^H\/(\d+)$/);
  if (hInterval) {
    const step = Number(hInterval[1]);
    if (step < 1) errors.push(`${label}: 간격은 1 이상이어야 합니다.`);
    return errors;
  }

  const hRange = part.match(/^H\((\d+)-(\d+)\)$/);
  if (hRange) {
    const [start, end] = [Number(hRange[1]), Number(hRange[2])];
    if (start < def.min || start > def.max) 
      errors.push(`${label}: 시작값 ${start}이(가) 범위(${def.min}-${def.max})를 벗어납니다.`);
    if (end < def.min || end > def.max)
      errors.push(`${label}: 끝값 ${end}이(가) 범위(${def.min}-${def.max})를 벗어납니다.`);
    return errors;
  }

  // 범위도 허용할지 여부에 따라 결정
  if (/^\d+-\d+$/.test(part)) {
    // 현재 코드: 허용, 새 정책: 거부할 수도 있음
    const [start, end] = part.split("-").map(Number);
    if (start < def.min || start > def.max) 
      errors.push(`${label}: 시작값 ${start}이(가) 범위(${def.min}-${def.max})를 벗어납니다.`);
    if (end < def.min || end > def.max)
      errors.push(`${label}: 끝값 ${end}이(가) 범위(${def.min}-${def.max})를 벗어납니다.`);
    return errors;
  }

  errors.push(`${label}: '${part}' — Jenkins에서는 H 기반 표현식을 사용하세요. (H, H/n, H(n-m))`);
  return errors;
}

function validateExpression(expr: string, platform: CronPlatform): { valid: boolean; errors: string[] } {
  const parts = expr.trim().split(/\s+/).filter(Boolean);
  const defs = FIELD_DEFS[platform];
  const errors: string[] = [];

  if (parts.length !== defs.length) {
    errors.push(`필드 수가 맞지 않습니다. ${platform} 형식은 ${defs.length}개 필드가 필요합니다. (입력: ${parts.length}개)`);
    return { valid: false, errors };
  }

  for (let i = 0; i < defs.length; i++) {
    const part = parts[i];
    const def = defs[i];
    
    if (platform === "jenkins") {
      errors.push(...validateJenkinsField(part, def));
    } else {
      // 일반 Linux/Spring/Quartz 검증
      errors.push(...validateLinuxField(part, def, platform));
    }
  }

  return { valid: errors.length === 0, errors };
}
```

---

## ✅ 긍정적 관찰

1. **배열 불변성 보호** (라인 215, 235): `[...field.specific].sort()`로 원본 배열 보존
2. **useMemo 최적화** (라인 770): `breakdownParts` 메모이제이션으로 불필요한 재계산 방지
3. **입력 검증 견고성** (라인 910-925): `parseInt`, `isNaN`, 범위 필터링으로 safe parsing
4. **필터링 효율성**: `.filter(Boolean)` 사용으로 빈 토큰 제거 (라인 770)

---

## 📝 권장 우선조치

| 우선순위 | 항목 | 실행 |
|---------|------|------|
| **🔴 높음** | Jenkins 정책 (설명 vs 코드) 일치화 | PR 설명 수정 또는 코드 범위 제한 |
| **🟡 중간** | `validateJenkinsField` 추출 | Jenkins/Linux 검증 로직 분리 |
| **🟡 중간** | ALL_FIELD_DEFS 런타임 검증 | makeFields에 방어 로직 추가 |
| **🟢 낮음** | parseField 중복 제거 | 함수 추출 및 재사용 |

<!-- end of auto-generated comment: release notes by coderabbit.ai -->