### PR TITLE
feat: UTC/Unix 계산기 확장 및 전역 UI 개선

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -44,6 +44,20 @@
   --url-panel-icon-bg: rgba(59, 130, 246, 0.15);
   --url-panel-accent: #2563eb;
   --url-panel-chip-bg: rgba(59, 130, 246, 0.1);
+
+  /* UTC Calculator result panels */
+  --utc-to-local-output-bg: rgba(14, 165, 233, 0.1);
+  --utc-to-local-output-border: rgba(14, 165, 233, 0.32);
+  --local-to-utc-output-bg: rgba(249, 115, 22, 0.1);
+  --local-to-utc-output-border: rgba(249, 115, 22, 0.3);
+  --unix-to-date-output-bg: rgba(20, 184, 166, 0.1);
+  --unix-to-date-output-border: rgba(20, 184, 166, 0.32);
+  --date-to-unix-output-bg: rgba(34, 197, 94, 0.1);
+  --date-to-unix-output-border: rgba(34, 197, 94, 0.3);
+  --danger-output-bg: rgba(239, 68, 68, 0.12);
+  --danger-output-border: rgba(239, 68, 68, 0.35);
+  --purple-output-bg: rgba(168, 85, 247, 0.12);
+  --purple-output-border: rgba(168, 85, 247, 0.34);
 }
 
 @theme inline {
@@ -108,6 +122,20 @@ html.theme-dark {
   --url-panel-icon-bg: rgba(96, 165, 250, 0.2);
   --url-panel-accent: #93c5fd;
   --url-panel-chip-bg: rgba(96, 165, 250, 0.15);
+
+  /* UTC Calculator result panels */
+  --utc-to-local-output-bg: rgba(14, 165, 233, 0.16);
+  --utc-to-local-output-border: rgba(56, 189, 248, 0.45);
+  --local-to-utc-output-bg: rgba(249, 115, 22, 0.16);
+  --local-to-utc-output-border: rgba(251, 146, 60, 0.45);
+  --unix-to-date-output-bg: rgba(20, 184, 166, 0.16);
+  --unix-to-date-output-border: rgba(45, 212, 191, 0.45);
+  --date-to-unix-output-bg: rgba(34, 197, 94, 0.16);
+  --date-to-unix-output-border: rgba(74, 222, 128, 0.45);
+  --danger-output-bg: rgba(248, 113, 113, 0.18);
+  --danger-output-border: rgba(248, 113, 113, 0.45);
+  --purple-output-bg: rgba(192, 132, 252, 0.18);
+  --purple-output-border: rgba(192, 132, 252, 0.45);
 }
 
 body {
@@ -126,6 +154,17 @@ input[type="datetime-local"]::-webkit-calendar-picker-indicator {
 
 html.theme-dark input[type="datetime-local"]::-webkit-calendar-picker-indicator {
   filter: invert(1);
+}
+
+.tool-input[type="number"] {
+  appearance: textfield;
+  -moz-appearance: textfield;
+}
+
+.tool-input[type="number"]::-webkit-outer-spin-button,
+.tool-input[type="number"]::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
 }
 
 @keyframes float-slow {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -30,8 +30,13 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
       <head>
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `(function(){try{var stored=localStorage.getItem("theme-mode");var isDark=stored?stored==="dark":true;document.documentElement.classList.toggle("theme-dark",isDark);}catch(_){document.documentElement.classList.add("theme-dark");}})();`,
+          }}
+        />
         <Script
           async
           strategy="afterInteractive"

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -230,8 +230,8 @@ export default function Home() {
                   placeholder="Type a tool name"
                 />
                 <Button
-                  className="h-10 rounded-2xl bg-[var(--accent-2)] px-4 text-xs font-semibold text-white transition hover:opacity-90 sm:h-12 sm:px-6 sm:text-sm">
-                  Go
+                  className="h-10 rounded-xl border border-[color:var(--date-to-unix-output-border)] bg-[var(--date-to-unix-output-bg)] px-4 text-xs font-semibold tracking-[0.04em] text-[var(--foreground)] transition hover:brightness-95 sm:h-12 sm:px-6 sm:text-sm">
+                  Search
                 </Button>
               </div>
               <div className="flex flex-col gap-2">

--- a/src/components/error-boundary.tsx
+++ b/src/components/error-boundary.tsx
@@ -25,7 +25,7 @@ export class ErrorBoundary extends Component<Props, State> {
           <p className="text-sm text-[var(--muted)]">문제가 발생했습니다.</p>
           <Button
             onClick={() => this.setState({ hasError: false })}
-            className="rounded-2xl bg-blue-600 px-6 text-sm font-semibold text-white hover:bg-blue-700"
+            className="rounded-xl border border-[color:var(--utc-to-local-output-border)] bg-[var(--utc-to-local-output-bg)] px-6 text-sm font-semibold text-[var(--foreground)] transition hover:brightness-95"
           >
             다시 시도
           </Button>

--- a/src/components/theme-provider.tsx
+++ b/src/components/theme-provider.tsx
@@ -13,23 +13,27 @@ type ThemeContextValue = {
 const ThemeContext = createContext<ThemeContextValue | null>(null);
 
 export function ThemeProvider({ children }: { children: ReactNode }) {
-  const [theme, setTheme] = useState<ThemeMode>("light");
+  const [theme, setTheme] = useState<ThemeMode>(() => {
+    if (typeof window === "undefined") {
+      return "dark";
+    }
+    const stored = window.localStorage.getItem("theme-mode");
+    if (stored === "dark" || stored === "light") {
+      return stored;
+    }
+    return "dark";
+  });
   const [mounted, setMounted] = useState(false);
 
   useEffect(() => {
-    const stored = localStorage.getItem("theme-mode");
-    if (stored === "dark" || stored === "light") {
-      setTheme(stored);
-      document.documentElement.classList.toggle("theme-dark", stored === "dark");
-    }
-    setMounted(true);
+    const timer = window.setTimeout(() => setMounted(true), 0);
+    return () => window.clearTimeout(timer);
   }, []);
 
   useEffect(() => {
-    if (!mounted) return;
     document.documentElement.classList.toggle("theme-dark", theme === "dark");
-    localStorage.setItem("theme-mode", theme);
-  }, [theme, mounted]);
+    window.localStorage.setItem("theme-mode", theme);
+  }, [theme]);
 
   const toggleTheme = useCallback(() => {
     setTheme((prev) => (prev === "dark" ? "light" : "dark"));

--- a/src/components/tool-ui.tsx
+++ b/src/components/tool-ui.tsx
@@ -47,12 +47,43 @@ export function ToolCard({ className, children }: { className?: string; children
   );
 }
 
-export function ToolBadge({ className, children }: { className?: string; children: ReactNode }) {
+export function ToolBadge({
+  className,
+  children,
+  tone = "default",
+}: {
+  className?: string;
+  children: ReactNode;
+  tone?: "default" | "sky" | "orange" | "teal" | "green" | "red" | "purple" | "neutral" | "rose" | "cyan" | "lime";
+}) {
+  const toneClass =
+    tone === "sky"
+      ? "border-[color:var(--utc-to-local-output-border)] bg-[var(--utc-to-local-output-bg)] text-[var(--foreground)]"
+      : tone === "orange"
+        ? "border-[color:var(--local-to-utc-output-border)] bg-[var(--local-to-utc-output-bg)] text-[var(--foreground)]"
+        : tone === "teal"
+          ? "border-[color:var(--unix-to-date-output-border)] bg-[var(--unix-to-date-output-bg)] text-[var(--foreground)]"
+          : tone === "green"
+            ? "border-[color:var(--date-to-unix-output-border)] bg-[var(--date-to-unix-output-bg)] text-[var(--foreground)]"
+            : tone === "red"
+              ? "border-[color:var(--danger-output-border)] bg-[var(--danger-output-bg)] text-[var(--foreground)]"
+                : tone === "purple"
+                ? "border-[color:var(--purple-output-border)] bg-[var(--purple-output-bg)] text-[var(--foreground)]"
+                : tone === "rose"
+                    ? "border-rose-300/70 bg-rose-100/70 text-[var(--foreground)] dark:border-rose-300/40 dark:bg-rose-300/15"
+                    : tone === "cyan"
+                        ? "border-cyan-300/70 bg-cyan-100/70 text-[var(--foreground)] dark:border-cyan-300/40 dark:bg-cyan-300/15"
+                        : tone === "lime"
+                          ? "border-lime-300/70 bg-lime-100/70 text-[var(--foreground)] dark:border-lime-300/40 dark:bg-lime-300/15"
+                : tone === "neutral"
+                  ? "border-[color:var(--card-border)] bg-[var(--surface-muted)] text-[var(--foreground)]"
+            : "border-[color:var(--date-to-unix-output-border)] bg-[var(--date-to-unix-output-bg)] text-[var(--foreground)]";
   return (
     <Badge
       variant="outline"
       className={cn(
-        "self-start cursor-default rounded-full border border-transparent bg-[var(--accent-2)] px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-white",
+        "self-start cursor-default rounded-xl border px-3 py-1 text-xs font-semibold tracking-[0.06em]",
+        toneClass,
         className,
       )}
     >
@@ -64,14 +95,32 @@ export function ToolBadge({ className, children }: { className?: string; childre
 export function ToolActionButton({
   className,
   children,
+  tone = "sky",
   ...props
-}: ComponentProps<typeof Button>) {
+}: ComponentProps<typeof Button> & {
+  tone?: "sky" | "orange" | "teal" | "green" | "red" | "purple" | "neutral";
+}) {
+  const toneClass =
+    tone === "sky"
+      ? "border-[color:var(--utc-to-local-output-border)] bg-[var(--utc-to-local-output-bg)]"
+      : tone === "orange"
+        ? "border-[color:var(--local-to-utc-output-border)] bg-[var(--local-to-utc-output-bg)]"
+        : tone === "teal"
+          ? "border-[color:var(--unix-to-date-output-border)] bg-[var(--unix-to-date-output-bg)]"
+          : tone === "green"
+            ? "border-[color:var(--date-to-unix-output-border)] bg-[var(--date-to-unix-output-bg)]"
+            : tone === "red"
+              ? "border-[color:var(--danger-output-border)] bg-[var(--danger-output-bg)]"
+              : tone === "purple"
+                ? "border-[color:var(--purple-output-border)] bg-[var(--purple-output-bg)]"
+                : "border-[color:var(--card-border)] bg-[var(--surface-muted)]";
   return (
     <Button
       variant="ghost"
       size="sm"
       className={cn(
-        "cursor-pointer h-auto rounded-full border border-[color:var(--card-border)] bg-[var(--surface)] px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.16em] text-[var(--muted)] transition hover:border-[color:var(--card-border-hover)] hover:text-[var(--foreground)]",
+        "cursor-pointer h-auto rounded-xl border px-3 py-1 text-xs font-semibold text-[var(--foreground)] transition hover:brightness-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--card-border-hover)] disabled:cursor-not-allowed disabled:opacity-50",
+        toneClass,
         className,
       )}
       {...props}
@@ -152,7 +201,7 @@ export function ToolInput({ className, ...props }: ComponentProps<typeof Input>)
   return (
     <Input
       className={cn(
-        "h-9 rounded-xl border border-[color:var(--card-border)] bg-[var(--surface-muted)] px-3 text-sm text-[var(--foreground)] focus:border-[color:var(--card-border-hover)] focus:outline-none",
+        "tool-input h-9 rounded-xl border border-[color:var(--card-border)] bg-[var(--surface-muted)] px-3 text-sm text-[var(--foreground)] focus:border-[color:var(--card-border-hover)] focus:outline-none",
         className,
       )}
       {...props}
@@ -190,7 +239,7 @@ export function ToolAddButton({ className, children, ...props }: ComponentProps<
       variant="ghost"
       size="sm"
       className={cn(
-        "cursor-pointer h-auto rounded-full bg-blue-600 px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.16em] text-white transition hover:bg-blue-700",
+        "cursor-pointer h-auto rounded-xl border border-[color:var(--utc-to-local-output-border)] bg-[var(--utc-to-local-output-bg)] px-3 py-1 text-xs font-semibold text-[var(--foreground)] transition hover:brightness-95",
         className,
       )}
       {...props}
@@ -200,14 +249,14 @@ export function ToolAddButton({ className, children, ...props }: ComponentProps<
   );
 }
 
-export function ToolRemoveButton({ className, children = "삭제", ...props }: ComponentProps<typeof Button>) {
+export function ToolRemoveButton({ className, children = "Remove", ...props }: ComponentProps<typeof Button>) {
   return (
     <Button
       type="button"
       variant="ghost"
       size="sm"
       className={cn(
-        "cursor-pointer h-7 rounded-full bg-red-500 px-2 text-[10px] font-semibold text-white transition hover:bg-red-600",
+        "cursor-pointer h-8 rounded-xl border border-[rgba(239,68,68,0.35)] bg-[rgba(239,68,68,0.12)] px-3 text-xs font-semibold text-[var(--foreground)] transition hover:brightness-95 dark:border-[rgba(248,113,113,0.45)] dark:bg-[rgba(248,113,113,0.18)]",
         className,
       )}
       {...props}

--- a/src/components/tool-ui.tsx
+++ b/src/components/tool-ui.tsx
@@ -8,6 +8,33 @@ import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { cn } from "@/lib/utils";
 
+type ToolBadgeTone = "default" | "sky" | "orange" | "teal" | "green" | "red" | "purple" | "neutral" | "rose" | "cyan" | "lime";
+type ToolActionTone = "sky" | "orange" | "teal" | "green" | "red" | "purple" | "neutral";
+
+const TOOL_BADGE_TONE_CLASS: Record<ToolBadgeTone, string> = {
+  default: "border-[color:var(--date-to-unix-output-border)] bg-[var(--date-to-unix-output-bg)] text-[var(--foreground)]",
+  sky: "border-[color:var(--utc-to-local-output-border)] bg-[var(--utc-to-local-output-bg)] text-[var(--foreground)]",
+  orange: "border-[color:var(--local-to-utc-output-border)] bg-[var(--local-to-utc-output-bg)] text-[var(--foreground)]",
+  teal: "border-[color:var(--unix-to-date-output-border)] bg-[var(--unix-to-date-output-bg)] text-[var(--foreground)]",
+  green: "border-[color:var(--date-to-unix-output-border)] bg-[var(--date-to-unix-output-bg)] text-[var(--foreground)]",
+  red: "border-[color:var(--danger-output-border)] bg-[var(--danger-output-bg)] text-[var(--foreground)]",
+  purple: "border-[color:var(--purple-output-border)] bg-[var(--purple-output-bg)] text-[var(--foreground)]",
+  neutral: "border-[color:var(--card-border)] bg-[var(--surface-muted)] text-[var(--foreground)]",
+  rose: "border-rose-300/70 bg-rose-100/70 text-[var(--foreground)] dark:border-rose-300/40 dark:bg-rose-300/15",
+  cyan: "border-cyan-300/70 bg-cyan-100/70 text-[var(--foreground)] dark:border-cyan-300/40 dark:bg-cyan-300/15",
+  lime: "border-lime-300/70 bg-lime-100/70 text-[var(--foreground)] dark:border-lime-300/40 dark:bg-lime-300/15",
+};
+
+const TOOL_ACTION_TONE_CLASS: Record<ToolActionTone, string> = {
+  sky: "border-[color:var(--utc-to-local-output-border)] bg-[var(--utc-to-local-output-bg)]",
+  orange: "border-[color:var(--local-to-utc-output-border)] bg-[var(--local-to-utc-output-bg)]",
+  teal: "border-[color:var(--unix-to-date-output-border)] bg-[var(--unix-to-date-output-bg)]",
+  green: "border-[color:var(--date-to-unix-output-border)] bg-[var(--date-to-unix-output-bg)]",
+  red: "border-[color:var(--danger-output-border)] bg-[var(--danger-output-bg)]",
+  purple: "border-[color:var(--purple-output-border)] bg-[var(--purple-output-bg)]",
+  neutral: "border-[color:var(--card-border)] bg-[var(--surface-muted)]",
+};
+
 export function ToolPage({ children, className }: { children: ReactNode; className?: string }) {
   return <div className={cn("flex flex-col gap-8", className)}>{children}</div>;
 }
@@ -54,30 +81,9 @@ export function ToolBadge({
 }: {
   className?: string;
   children: ReactNode;
-  tone?: "default" | "sky" | "orange" | "teal" | "green" | "red" | "purple" | "neutral" | "rose" | "cyan" | "lime";
+  tone?: ToolBadgeTone;
 }) {
-  const toneClass =
-    tone === "sky"
-      ? "border-[color:var(--utc-to-local-output-border)] bg-[var(--utc-to-local-output-bg)] text-[var(--foreground)]"
-      : tone === "orange"
-        ? "border-[color:var(--local-to-utc-output-border)] bg-[var(--local-to-utc-output-bg)] text-[var(--foreground)]"
-        : tone === "teal"
-          ? "border-[color:var(--unix-to-date-output-border)] bg-[var(--unix-to-date-output-bg)] text-[var(--foreground)]"
-          : tone === "green"
-            ? "border-[color:var(--date-to-unix-output-border)] bg-[var(--date-to-unix-output-bg)] text-[var(--foreground)]"
-            : tone === "red"
-              ? "border-[color:var(--danger-output-border)] bg-[var(--danger-output-bg)] text-[var(--foreground)]"
-                : tone === "purple"
-                ? "border-[color:var(--purple-output-border)] bg-[var(--purple-output-bg)] text-[var(--foreground)]"
-                : tone === "rose"
-                    ? "border-rose-300/70 bg-rose-100/70 text-[var(--foreground)] dark:border-rose-300/40 dark:bg-rose-300/15"
-                    : tone === "cyan"
-                        ? "border-cyan-300/70 bg-cyan-100/70 text-[var(--foreground)] dark:border-cyan-300/40 dark:bg-cyan-300/15"
-                        : tone === "lime"
-                          ? "border-lime-300/70 bg-lime-100/70 text-[var(--foreground)] dark:border-lime-300/40 dark:bg-lime-300/15"
-                : tone === "neutral"
-                  ? "border-[color:var(--card-border)] bg-[var(--surface-muted)] text-[var(--foreground)]"
-            : "border-[color:var(--date-to-unix-output-border)] bg-[var(--date-to-unix-output-bg)] text-[var(--foreground)]";
+  const toneClass = TOOL_BADGE_TONE_CLASS[tone] ?? TOOL_BADGE_TONE_CLASS.default;
   return (
     <Badge
       variant="outline"
@@ -98,22 +104,9 @@ export function ToolActionButton({
   tone = "sky",
   ...props
 }: ComponentProps<typeof Button> & {
-  tone?: "sky" | "orange" | "teal" | "green" | "red" | "purple" | "neutral";
+  tone?: ToolActionTone;
 }) {
-  const toneClass =
-    tone === "sky"
-      ? "border-[color:var(--utc-to-local-output-border)] bg-[var(--utc-to-local-output-bg)]"
-      : tone === "orange"
-        ? "border-[color:var(--local-to-utc-output-border)] bg-[var(--local-to-utc-output-bg)]"
-        : tone === "teal"
-          ? "border-[color:var(--unix-to-date-output-border)] bg-[var(--unix-to-date-output-bg)]"
-          : tone === "green"
-            ? "border-[color:var(--date-to-unix-output-border)] bg-[var(--date-to-unix-output-bg)]"
-            : tone === "red"
-              ? "border-[color:var(--danger-output-border)] bg-[var(--danger-output-bg)]"
-              : tone === "purple"
-                ? "border-[color:var(--purple-output-border)] bg-[var(--purple-output-bg)]"
-                : "border-[color:var(--card-border)] bg-[var(--surface-muted)]";
+  const toneClass = TOOL_ACTION_TONE_CLASS[tone] ?? TOOL_ACTION_TONE_CLASS.sky;
   return (
     <Button
       variant="ghost"

--- a/src/lib/tools.ts
+++ b/src/lib/tools.ts
@@ -64,10 +64,10 @@ export const tools: ToolItem[] = [
     createdAt: "2026-02-21",
   },
   {
-    title: "UTC Calculator",
-    desc: "Convert UTC and local timezone datetimes for logs, incidents, and schedules.",
+    title: "UTC & Unix Time Calculator",
+    desc: "Convert UTC/local datetimes and Unix timestamps (seconds/milliseconds) across timezones for logs, incidents, and schedules.",
     tag: "DevOps",
-    slug: "utc-calculator",
+    slug: "utc-unix-calculator",
     createdAt: "2026-03-04",
   },
 ];

--- a/src/tools/base64.tsx
+++ b/src/tools/base64.tsx
@@ -91,6 +91,7 @@ export default function Base64Tool({ tool }: { tool: ToolItem }) {
             <ToolActionButton
               type="button"
               onClick={() => handleClear("plain")}
+              className="border-[color:var(--local-to-utc-output-border)] bg-[var(--local-to-utc-output-bg)]"
             >
               {clearState === "plain" ? "Cleared" : "Clear"}
             </ToolActionButton>
@@ -109,6 +110,7 @@ export default function Base64Tool({ tool }: { tool: ToolItem }) {
             <ToolActionButton
               type="button"
               onClick={() => copy(encoded, "encoded")}
+              tone="teal"
             >
               {isCopied("encoded") ? "Copied" : "Copy"}
             </ToolActionButton>
@@ -131,6 +133,7 @@ export default function Base64Tool({ tool }: { tool: ToolItem }) {
             <ToolActionButton
               type="button"
               onClick={() => handleClear("base64")}
+              className="border-[color:var(--local-to-utc-output-border)] bg-[var(--local-to-utc-output-bg)]"
             >
               {clearState === "base64" ? "Cleared" : "Clear"}
             </ToolActionButton>
@@ -149,6 +152,7 @@ export default function Base64Tool({ tool }: { tool: ToolItem }) {
             <ToolActionButton
               type="button"
               onClick={() => copy(decoded, "decoded")}
+              tone="teal"
             >
               {isCopied("decoded") ? "Copied" : "Copy"}
             </ToolActionButton>

--- a/src/tools/base64.tsx
+++ b/src/tools/base64.tsx
@@ -91,7 +91,7 @@ export default function Base64Tool({ tool }: { tool: ToolItem }) {
             <ToolActionButton
               type="button"
               onClick={() => handleClear("plain")}
-              className="border-[color:var(--local-to-utc-output-border)] bg-[var(--local-to-utc-output-bg)]"
+              tone="orange"
             >
               {clearState === "plain" ? "Cleared" : "Clear"}
             </ToolActionButton>
@@ -133,7 +133,7 @@ export default function Base64Tool({ tool }: { tool: ToolItem }) {
             <ToolActionButton
               type="button"
               onClick={() => handleClear("base64")}
-              className="border-[color:var(--local-to-utc-output-border)] bg-[var(--local-to-utc-output-bg)]"
+              tone="orange"
             >
               {clearState === "base64" ? "Cleared" : "Clear"}
             </ToolActionButton>

--- a/src/tools/cron-generator.tsx
+++ b/src/tools/cron-generator.tsx
@@ -189,7 +189,7 @@ const PRESETS: Preset[] = [
 
 /* 표현식 생성 */
 
-function fieldToExpression(field: FieldState, def: FieldDef, platform: CronPlatform): string {
+function fieldToExpression(field: FieldState, def: FieldDef): string {
   switch (field.mode) {
     case "every":
       return "*";
@@ -218,7 +218,7 @@ function fieldToExpression(field: FieldState, def: FieldDef, platform: CronPlatf
 
 function buildExpression(fields: Record<FieldKey, FieldState>, platform: CronPlatform): string {
   const defs = FIELD_DEFS[platform];
-  return defs.map((def) => fieldToExpression(fields[def.key], def, platform)).join(" ");
+  return defs.map((def) => fieldToExpression(fields[def.key], def)).join(" ");
 }
 
 /* 표현식 해석 */
@@ -552,6 +552,7 @@ export default function CronGenerator({ tool }: { tool: ToolItem }) {
   /* 수동 입력 모드 */
   const [manualMode, setManualMode] = useState(false);
   const [manualExpr, setManualExpr] = useState("");
+  const [selectedPreset, setSelectedPreset] = useState<string | null>(null);
 
   /* Jenkins 해시 시드 (0~59) */
   const [hashSeed, setHashSeed] = useState(7);
@@ -615,6 +616,7 @@ export default function CronGenerator({ tool }: { tool: ToolItem }) {
         result.year = defaultField(YEAR_DEF);
       }
       setFields(result);
+      setSelectedPreset(null);
     },
     [fields],
   );
@@ -623,15 +625,18 @@ export default function CronGenerator({ tool }: { tool: ToolItem }) {
     (preset: Preset) => {
       setFields(preset.apply(platform));
       setManualMode(false);
+      setSelectedPreset(preset.label);
     },
     [platform],
   );
 
   const updateField = useCallback((key: FieldKey, patch: Partial<FieldState>) => {
+    setSelectedPreset(null);
     setFields((prev) => ({ ...prev, [key]: { ...prev[key], ...patch } }));
   }, []);
 
   const toggleSpecific = useCallback((key: FieldKey, val: number) => {
+    setSelectedPreset(null);
     setFields((prev) => {
       const field = prev[key];
       const specific = field.specific.includes(val) ? field.specific.filter((v) => v !== val) : [...field.specific, val];
@@ -645,10 +650,10 @@ export default function CronGenerator({ tool }: { tool: ToolItem }) {
 
   /* 스타일 */
   const tabBtnClass = (active: boolean) =>
-    `cursor-pointer h-8 rounded-full px-3 text-[11px] font-semibold uppercase tracking-[0.16em] transition ${
+    `cursor-pointer h-9 rounded-xl px-3 text-xs font-semibold tracking-[0.06em] transition hover:brightness-95 ${
       active
-        ? "bg-blue-600 text-white"
-        : "border border-[color:var(--card-border)] bg-[var(--surface)] text-[var(--muted)] hover:text-[var(--foreground)]"
+        ? "border border-[color:var(--utc-to-local-output-border)] bg-[var(--utc-to-local-output-bg)] text-[var(--foreground)]"
+        : "border border-[color:var(--card-border)] bg-[var(--surface-muted)] text-[var(--foreground)]"
     }`;
 
   const currentDefs = FIELD_DEFS[platform];
@@ -702,10 +707,10 @@ export default function CronGenerator({ tool }: { tool: ToolItem }) {
                   key={p.value}
                   type="button"
                   onClick={() => handlePlatformChange(p.value)}
-                  className={`cursor-pointer flex flex-col gap-1 rounded-2xl border p-3 text-left transition ${
+                  className={`cursor-pointer flex flex-col gap-1 rounded-2xl border p-3 text-left transition hover:brightness-95 ${
                     platform === p.value
-                      ? "border-blue-500 bg-blue-500/10 text-[var(--foreground)]"
-                      : "border-[color:var(--card-border)] bg-[var(--surface-muted)] text-[var(--muted)] hover:border-[color:var(--card-border-hover)]"
+                      ? "border-[color:var(--utc-to-local-output-border)] bg-[var(--utc-to-local-output-bg)] text-[var(--foreground)]"
+                      : "border-[color:var(--card-border)] bg-[var(--surface-muted)] text-[var(--muted)] hover:brightness-95"
                   }`}
                 >
                   <span className="text-sm font-semibold">{p.label}</span>
@@ -724,7 +729,11 @@ export default function CronGenerator({ tool }: { tool: ToolItem }) {
                   key={pr.label}
                   type="button"
                   onClick={() => applyPreset(pr)}
-                  className="cursor-pointer rounded-full border border-[color:var(--card-border)] bg-[var(--surface)] px-3 py-1.5 text-xs font-medium text-[var(--foreground)] transition hover:border-[color:var(--card-border-hover)] hover:bg-[var(--surface-muted)]"
+                  className={`cursor-pointer rounded-xl border px-3 py-1.5 text-xs font-semibold text-[var(--foreground)] transition hover:brightness-95 ${
+                    selectedPreset === pr.label
+                      ? "border-[color:var(--utc-to-local-output-border)] bg-[var(--utc-to-local-output-bg)]"
+                      : "border-[color:var(--card-border)] bg-[var(--surface-muted)]"
+                  }`}
                 >
                   {pr.label}
                 </button>
@@ -781,7 +790,7 @@ export default function CronGenerator({ tool }: { tool: ToolItem }) {
                   <div className="flex items-center justify-between">
                     <ToolBadge>{def.label}</ToolBadge>
                     <span className="font-mono text-xs text-[var(--muted)]">
-                      {fieldToExpression(fields[def.key], def, platform)}
+                      {fieldToExpression(fields[def.key], def)}
                     </span>
                   </div>
 
@@ -792,10 +801,10 @@ export default function CronGenerator({ tool }: { tool: ToolItem }) {
                         key={m.value}
                         type="button"
                         onClick={() => updateField(def.key, { mode: m.value })}
-                        className={`cursor-pointer rounded-full px-2.5 py-1 text-[10px] font-semibold transition ${
+                  className={`cursor-pointer rounded-xl border px-2.5 py-1.5 text-xs font-semibold transition hover:brightness-95 ${
                           fields[def.key].mode === m.value
-                            ? "bg-blue-600 text-white"
-                            : "border border-[color:var(--card-border)] bg-[var(--surface)] text-[var(--muted)] hover:text-[var(--foreground)]"
+                            ? "border-[color:var(--utc-to-local-output-border)] bg-[var(--utc-to-local-output-bg)] text-[var(--foreground)]"
+                            : "border-[color:var(--card-border)] bg-[var(--surface-muted)] text-[var(--foreground)]"
                         }`}
                       >
                         {m.label}
@@ -969,7 +978,7 @@ export default function CronGenerator({ tool }: { tool: ToolItem }) {
           <ToolCard>
             <div className="flex items-center justify-between">
               <ToolBadge>Generated Expression</ToolBadge>
-              <ToolActionButton type="button" onClick={handleCopy} disabled={!activeExpr.trim()}>
+              <ToolActionButton type="button" onClick={handleCopy} tone="teal" disabled={!activeExpr.trim()}>
                 {isCopied() ? "Copied!" : "Copy"}
               </ToolActionButton>
             </div>

--- a/src/tools/diff.tsx
+++ b/src/tools/diff.tsx
@@ -3,7 +3,7 @@
 import { useMemo, useState } from "react";
 import { Card } from "@/components/ui/card";
 import { Switch } from "@/components/ui/switch";
-import { ToolActionButton, ToolCard, ToolDiffText, ToolHeader, ToolInfoPanel, ToolPage, ToolTextarea } from "@/components/tool-ui";
+import { ToolActionButton, ToolBadge, ToolCard, ToolDiffText, ToolHeader, ToolInfoPanel, ToolPage, ToolTextarea } from "@/components/tool-ui";
 
 type LineStatus = "same" | "changed" | "added" | "removed";
 
@@ -290,7 +290,7 @@ export default function DiffTool({ tool }: { tool: ToolItem }) {
       </div>
 
       <ToolInfoPanel
-        icon="Δ"
+        icon="⇄"
         title="Text Diff"
         description="두 텍스트를 나란히 비교하여 변경된 부분을 하이라이트합니다. 추가/삭제/수정된 라인과 단어 단위 차이를 시각적으로 확인할 수 있습니다."
         chips={["라인 단위 비교", "단어 단위 하이라이트", "변경 사항만 필터"]}
@@ -299,13 +299,12 @@ export default function DiffTool({ tool }: { tool: ToolItem }) {
       <section className="grid gap-4 lg:grid-cols-2">
         <ToolCard>
           <div className="flex items-center justify-between text-xs uppercase tracking-[0.2em] text-[var(--muted)]">
-            <span>Left</span>
-            <div className="flex items-center gap-3">
-              <span>Original</span>
+            <ToolBadge tone="orange">Original</ToolBadge>
+            <div className="flex items-center gap-2">
               <ToolActionButton
                 type="button"
                 onClick={() => handleClear("left")}
-                className="px-2 py-1 font-normal"
+                className="border-[color:var(--local-to-utc-output-border)] bg-[var(--local-to-utc-output-bg)] px-2 py-1 font-normal"
               >
                 {clearState === "left" ? "Cleared" : "Clear"}
               </ToolActionButton>
@@ -319,13 +318,12 @@ export default function DiffTool({ tool }: { tool: ToolItem }) {
         </ToolCard>
         <ToolCard>
           <div className="flex items-center justify-between text-xs uppercase tracking-[0.2em] text-[var(--muted)]">
-            <span>Right</span>
-            <div className="flex items-center gap-3">
-              <span>Updated</span>
+            <ToolBadge tone="teal">Updated</ToolBadge>
+            <div className="flex items-center gap-2">
               <ToolActionButton
                 type="button"
                 onClick={() => handleClear("right")}
-                className="px-2 py-1 font-normal"
+                className="border-[color:var(--local-to-utc-output-border)] bg-[var(--local-to-utc-output-bg)] px-2 py-1 font-normal"
               >
                 {clearState === "right" ? "Cleared" : "Clear"}
               </ToolActionButton>
@@ -341,8 +339,12 @@ export default function DiffTool({ tool }: { tool: ToolItem }) {
 
       <Card className="overflow-hidden rounded-3xl border border-[color:var(--card-border)] bg-[var(--surface)] shadow-[var(--card-shadow)]">
         <div className="grid grid-cols-2 border-b border-[color:var(--card-border)] bg-[var(--surface-muted)] text-xs uppercase tracking-[0.2em] text-[var(--muted)]">
-          <div className="px-4 py-3">Left</div>
-          <div className="px-4 py-3">Right</div>
+          <div className="px-4 py-3">
+            <ToolBadge tone="orange">Original</ToolBadge>
+          </div>
+          <div className="px-4 py-3">
+            <ToolBadge tone="teal">Updated</ToolBadge>
+          </div>
         </div>
         <div className="divide-y divide-[color:var(--card-border)]">
           {diffRows.map((row) => {

--- a/src/tools/diff.tsx
+++ b/src/tools/diff.tsx
@@ -304,7 +304,8 @@ export default function DiffTool({ tool }: { tool: ToolItem }) {
               <ToolActionButton
                 type="button"
                 onClick={() => handleClear("left")}
-                className="border-[color:var(--local-to-utc-output-border)] bg-[var(--local-to-utc-output-bg)] px-2 py-1 font-normal"
+                tone="orange"
+                className="px-2 py-1 font-normal"
               >
                 {clearState === "left" ? "Cleared" : "Clear"}
               </ToolActionButton>
@@ -323,7 +324,8 @@ export default function DiffTool({ tool }: { tool: ToolItem }) {
               <ToolActionButton
                 type="button"
                 onClick={() => handleClear("right")}
-                className="border-[color:var(--local-to-utc-output-border)] bg-[var(--local-to-utc-output-bg)] px-2 py-1 font-normal"
+                tone="orange"
+                className="px-2 py-1 font-normal"
               >
                 {clearState === "right" ? "Cleared" : "Clear"}
               </ToolActionButton>

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -23,5 +23,5 @@ export const toolPages: Record<string, ComponentType<ToolComponentProps>> = {
   "java-memory-calculator": JavaMemoryCalculator,
   "k6-generator": K6Generator,
   "cron-generator": CronGenerator,
-  "utc-calculator": UtcCalculator,
+  "utc-unix-calculator": UtcCalculator,
 };

--- a/src/tools/java-memory-calculator.tsx
+++ b/src/tools/java-memory-calculator.tsx
@@ -2,7 +2,7 @@
 
 import { useMemo, useState } from "react";
 import { Textarea } from "@/components/ui/textarea";
-import { ToolActionButton, ToolCard, ToolHeader, ToolInfoPanel, ToolInput, ToolLabel, ToolOutput, ToolPage } from "@/components/tool-ui";
+import { ToolActionButton, ToolBadge, ToolCard, ToolHeader, ToolInfoPanel, ToolInput, ToolLabel, ToolOutput, ToolPage } from "@/components/tool-ui";
 import { useCopyToClipboard } from "@/hooks/use-copy-to-clipboard";
 
 import type { ToolItem } from "@/lib/tools";
@@ -96,7 +96,7 @@ function ResultPanel({
 
   return (
     <ToolCard className="gap-4">
-      <h3 className="text-xs font-semibold uppercase tracking-[0.2em] text-[var(--muted)]">Memory Allocation</h3>
+      <ToolBadge tone="neutral">Memory Allocation</ToolBadge>
 
       {/* 추천 모드 결과 */}
       {recommendedTotal !== undefined && (
@@ -176,10 +176,11 @@ function ResultPanel({
       {/* JVM 플래그 */}
       <div className="flex flex-col gap-2">
         <div className="flex items-center justify-between">
-          <h4 className="text-xs font-semibold uppercase tracking-[0.2em] text-[var(--muted)]">JVM Flags</h4>
+          <ToolBadge tone="neutral">JVM Flags</ToolBadge>
           <ToolActionButton
             type="button"
             onClick={() => copy(jvmFlags)}
+            tone="teal"
             disabled={isError}
           >
             {isCopied() ? "Copied" : "Copy"}
@@ -399,8 +400,10 @@ export default function JavaMemoryCalculator({ tool }: { tool: ToolItem }) {
 
   /* 스타일 클래스 */
   const modeTabClass = (active: boolean) =>
-    `cursor-pointer px-4 py-2 text-xs font-semibold transition rounded-lg ${
-      active ? "bg-blue-600 text-white" : "bg-gray-200 text-gray-600 hover:text-gray-900"
+    `cursor-pointer rounded-xl border px-4 py-2 text-xs font-semibold transition hover:brightness-95 ${
+      active
+        ? "border-[color:var(--utc-to-local-output-border)] bg-[var(--utc-to-local-output-bg)] text-[var(--foreground)]"
+        : "border-[color:var(--card-border)] bg-[var(--surface-muted)] text-[var(--foreground)]"
     }`;
 
   return (
@@ -451,7 +454,7 @@ export default function JavaMemoryCalculator({ tool }: { tool: ToolItem }) {
       {mode === "calculate" && (
         <section className="grid gap-4 lg:grid-cols-2">
           <ToolCard className="gap-4">
-            <h3 className="text-xs font-semibold uppercase tracking-[0.2em] text-[var(--muted)]">Configuration</h3>
+            <ToolBadge tone="neutral">Configuration</ToolBadge>
 
             <div className="flex flex-col gap-1.5">
               <ToolLabel>Total Memory</ToolLabel>
@@ -472,7 +475,11 @@ export default function JavaMemoryCalculator({ tool }: { tool: ToolItem }) {
                         setTotalMemory(totalMemory * 1024);
                       }
                     }}
-                    className={`cursor-pointer px-3 py-1 text-xs font-semibold transition ${memoryUnit === "MB" ? "bg-blue-600 text-white" : "bg-[var(--surface-muted)] text-[var(--muted)] hover:text-[var(--foreground)]"}`}
+                    className={`cursor-pointer px-3 py-1 text-xs font-semibold transition hover:brightness-95 ${
+                      memoryUnit === "MB"
+                        ? "bg-[var(--utc-to-local-output-bg)] text-[var(--foreground)]"
+                        : "bg-[var(--surface-muted)] text-[var(--muted)]"
+                    }`}
                   >
                     MB
                   </button>
@@ -484,7 +491,11 @@ export default function JavaMemoryCalculator({ tool }: { tool: ToolItem }) {
                         setTotalMemory(Math.max(1, Math.round(totalMemory / 1024)));
                       }
                     }}
-                    className={`cursor-pointer px-3 py-1 text-xs font-semibold transition ${memoryUnit === "GB" ? "bg-blue-600 text-white" : "bg-[var(--surface-muted)] text-[var(--muted)] hover:text-[var(--foreground)]"}`}
+                    className={`cursor-pointer px-3 py-1 text-xs font-semibold transition hover:brightness-95 ${
+                      memoryUnit === "GB"
+                        ? "bg-[var(--utc-to-local-output-bg)] text-[var(--foreground)]"
+                        : "bg-[var(--surface-muted)] text-[var(--muted)]"
+                    }`}
                   >
                     GB
                   </button>
@@ -755,7 +766,11 @@ export default function JavaMemoryCalculator({ tool }: { tool: ToolItem }) {
                         setQuickTotalMemory(quickTotalMemory * 1024);
                       }
                     }}
-                    className={`cursor-pointer px-3 py-1 text-xs font-semibold transition ${quickMemoryUnit === "MB" ? "bg-blue-600 text-white" : "bg-[var(--surface-muted)] text-[var(--muted)] hover:text-[var(--foreground)]"}`}
+                    className={`cursor-pointer px-3 py-1 text-xs font-semibold transition hover:brightness-95 ${
+                      quickMemoryUnit === "MB"
+                        ? "bg-[var(--utc-to-local-output-bg)] text-[var(--foreground)]"
+                        : "bg-[var(--surface-muted)] text-[var(--muted)]"
+                    }`}
                   >
                     MB
                   </button>
@@ -767,7 +782,11 @@ export default function JavaMemoryCalculator({ tool }: { tool: ToolItem }) {
                         setQuickTotalMemory(Math.max(1, Math.round(quickTotalMemory / 1024)));
                       }
                     }}
-                    className={`cursor-pointer px-3 py-1 text-xs font-semibold transition ${quickMemoryUnit === "GB" ? "bg-blue-600 text-white" : "bg-[var(--surface-muted)] text-[var(--muted)] hover:text-[var(--foreground)]"}`}
+                    className={`cursor-pointer px-3 py-1 text-xs font-semibold transition hover:brightness-95 ${
+                      quickMemoryUnit === "GB"
+                        ? "bg-[var(--utc-to-local-output-bg)] text-[var(--foreground)]"
+                        : "bg-[var(--surface-muted)] text-[var(--muted)]"
+                    }`}
                   >
                     GB
                   </button>

--- a/src/tools/jsonviewer.tsx
+++ b/src/tools/jsonviewer.tsx
@@ -599,7 +599,8 @@ export default function JsonViewerTool({ tool }: { tool: ToolItem }) {
               <ToolActionButton
                 type="button"
                 onClick={handleClearRaw}
-                className="h-8 border-[color:var(--local-to-utc-output-border)] bg-[var(--local-to-utc-output-bg)] px-3"
+                tone="orange"
+                className="h-8 px-3"
               >
                 Clear
               </ToolActionButton>

--- a/src/tools/jsonviewer.tsx
+++ b/src/tools/jsonviewer.tsx
@@ -6,7 +6,7 @@ import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
 import { Textarea } from "@/components/ui/textarea";
 import type { ToolItem } from "@/lib/tools";
-import { ToolActionButton, ToolCard, ToolHeader, ToolInfoPanel, ToolPage } from "@/components/tool-ui";
+import { ToolActionButton, ToolBadge, ToolCard, ToolHeader, ToolInfoPanel, ToolPage } from "@/components/tool-ui";
 
 type JsonPrimitive = string | number | boolean | null;
 type JsonObject = { [key: string]: JsonValue };
@@ -572,40 +572,41 @@ export default function JsonViewerTool({ tool }: { tool: ToolItem }) {
         >
         <ToolCard className="min-h-[520px] gap-4">
           <div className="flex flex-wrap items-center justify-between gap-2">
-            <p className="shrink-0 text-xs font-semibold uppercase tracking-[0.2em] text-[var(--muted)]">Raw JSON</p>
+            <ToolBadge tone="neutral">Raw JSON</ToolBadge>
             <div className="flex flex-wrap gap-1.5">
               <ToolActionButton
                 type="button"
                 onClick={handleCopyRaw}
-                className="h-7 px-3"
+                tone="teal"
+                className="h-8 px-3"
               >
                 {rightCopyState === "copied" ? "Copied" : "Copy"}
               </ToolActionButton>
               <ToolActionButton
                 type="button"
                 onClick={handleToggleRawFormat}
-                className="h-7 px-3"
+                className="h-8 px-3"
               >
                 {isMinified ? "Expand all" : "Collapse all"}
               </ToolActionButton>
               <ToolActionButton
                 type="button"
                 onClick={handleReset}
-                className="h-7 px-3"
+                className="h-8 px-3"
               >
                 Reset sample
               </ToolActionButton>
               <ToolActionButton
                 type="button"
                 onClick={handleClearRaw}
-                className="h-7 px-3"
+                className="h-8 border-[color:var(--local-to-utc-output-border)] bg-[var(--local-to-utc-output-bg)] px-3"
               >
                 Clear
               </ToolActionButton>
               <ToolActionButton
                 type="button"
                 onClick={() => setExpandedPanel(expandedPanel === "raw" ? "none" : "raw")}
-                className="hidden lg:inline-flex h-7 px-3"
+                className="hidden lg:inline-flex h-8 px-3"
               >
                 {expandedPanel === "raw" ? "Shrink" : "Expand"}
               </ToolActionButton>
@@ -677,26 +678,27 @@ export default function JsonViewerTool({ tool }: { tool: ToolItem }) {
         <div className={expandedPanel === "raw" ? "hidden lg:hidden" : "flex-1 min-w-0"}>
         <ToolCard className="min-h-[520px] gap-4">
           <div className="flex flex-wrap items-center justify-between gap-2">
-            <p className="shrink-0 text-xs font-semibold uppercase tracking-[0.2em] text-[var(--muted)]">Tree Viewer</p>
+            <ToolBadge tone="neutral">Tree Viewer</ToolBadge>
             <div className="flex flex-wrap gap-1.5">
               <ToolActionButton
                 type="button"
                 onClick={handleCopyTree}
-                className="h-7 px-3"
+                tone="teal"
+                className="h-8 px-3"
               >
                 {leftCopyState === "copied" ? "Copied" : "Copy"}
               </ToolActionButton>
               <ToolActionButton
                 type="button"
                 onClick={handleToggleAll}
-                className="h-7 px-3"
+                className="h-8 px-3"
               >
                 {isAllCollapsed ? "Expand all" : "Collapse all"}
               </ToolActionButton>
               <ToolActionButton
                 type="button"
                 onClick={() => setExpandedPanel(expandedPanel === "tree" ? "none" : "tree")}
-                className="hidden lg:inline-flex h-7 px-3"
+                className="hidden lg:inline-flex h-8 px-3"
               >
                 {expandedPanel === "tree" ? "Shrink" : "Expand"}
               </ToolActionButton>

--- a/src/tools/jwt.tsx
+++ b/src/tools/jwt.tsx
@@ -255,7 +255,7 @@ export default function JwtTool({ tool }: { tool: ToolItem }) {
             <ToolActionButton
               type="button"
               onClick={() => handleJwtInputChange("")}
-              className="border-[color:var(--local-to-utc-output-border)] bg-[var(--local-to-utc-output-bg)]"
+              tone="orange"
             >
               Clear
             </ToolActionButton>

--- a/src/tools/jwt.tsx
+++ b/src/tools/jwt.tsx
@@ -252,7 +252,11 @@ export default function JwtTool({ tool }: { tool: ToolItem }) {
         <ToolCard>
           <div className="flex items-center justify-between text-xs uppercase tracking-[0.2em] text-[var(--muted)] font-semibold">
             <ToolBadge>Decode JWT</ToolBadge>
-            <ToolActionButton type="button" onClick={() => handleJwtInputChange("")}>
+            <ToolActionButton
+              type="button"
+              onClick={() => handleJwtInputChange("")}
+              className="border-[color:var(--local-to-utc-output-border)] bg-[var(--local-to-utc-output-bg)]"
+            >
               Clear
             </ToolActionButton>
           </div>
@@ -274,6 +278,7 @@ export default function JwtTool({ tool }: { tool: ToolItem }) {
                   <ToolActionButton
                     type="button"
                     onClick={() => copy(decoded.header, "header")}
+                    tone="teal"
                   >
                     {isCopied("header") ? "Copied" : "Copy"}
                   </ToolActionButton>
@@ -287,6 +292,7 @@ export default function JwtTool({ tool }: { tool: ToolItem }) {
                   <ToolActionButton
                     type="button"
                     onClick={() => copy(decoded.payload, "payload")}
+                    tone="teal"
                   >
                     {isCopied("payload") ? "Copied" : "Copy"}
                   </ToolActionButton>
@@ -312,6 +318,7 @@ export default function JwtTool({ tool }: { tool: ToolItem }) {
                     <ToolActionButton
                       type="button"
                       onClick={() => copy(decoded.signature, "signature")}
+                      tone="teal"
                     >
                       {isCopied("signature") ? "Copied" : "Copy"}
                     </ToolActionButton>
@@ -413,10 +420,10 @@ export default function JwtTool({ tool }: { tool: ToolItem }) {
                 key={alg}
                 type="button"
                 onClick={() => handleEncAlgChange(alg)}
-                className={`rounded-full px-4 py-1.5 text-[11px] font-semibold uppercase tracking-[0.12em] transition ${
+                className={`cursor-pointer rounded-xl border px-4 py-1.5 text-xs font-semibold tracking-[0.06em] transition hover:brightness-95 ${
                   encAlg === alg
-                    ? "bg-[var(--foreground)] text-[var(--background)]"
-                    : "border border-[color:var(--card-border)] bg-[var(--surface)] text-[var(--muted)] hover:border-[color:var(--card-border-hover)] hover:text-[var(--foreground)]"
+                    ? "border-[color:var(--utc-to-local-output-border)] bg-[var(--utc-to-local-output-bg)] text-[var(--foreground)]"
+                    : "border-[color:var(--card-border)] bg-[var(--surface-muted)] text-[var(--foreground)]"
                 }`}
               >
                 {alg}
@@ -484,6 +491,7 @@ export default function JwtTool({ tool }: { tool: ToolItem }) {
               <ToolActionButton
                 type="button"
                 onClick={() => copy(encodedJwt, "encoded")}
+                tone="teal"
               >
                 {isCopied("encoded") ? "Copied" : "Copy"}
               </ToolActionButton>

--- a/src/tools/k6-generator.tsx
+++ b/src/tools/k6-generator.tsx
@@ -631,7 +631,7 @@ export default function K6Generator({ tool }: { tool: ToolItem }) {
                   <ToolActionButton
                     type="button"
                     onClick={() => setCustomScript("")}
-                    className="border-[color:var(--local-to-utc-output-border)] bg-[var(--local-to-utc-output-bg)]"
+                    tone="orange"
                   >
                     Clear
                   </ToolActionButton>
@@ -639,7 +639,7 @@ export default function K6Generator({ tool }: { tool: ToolItem }) {
                   <ToolActionButton
                     type="button"
                     onClick={handleClear}
-                    className="border-[color:var(--local-to-utc-output-border)] bg-[var(--local-to-utc-output-bg)]"
+                    tone="orange"
                   >
                     Clear
                   </ToolActionButton>

--- a/src/tools/k6-generator.tsx
+++ b/src/tools/k6-generator.tsx
@@ -434,10 +434,10 @@ export default function K6Generator({ tool }: { tool: ToolItem }) {
   const showBody = ["POST", "PUT", "PATCH"].includes(method);
 
   const tabBtnClass = (active: boolean) =>
-    `cursor-pointer h-8 rounded-full px-3 text-[11px] font-semibold uppercase tracking-[0.16em] transition ${
+    `cursor-pointer h-9 rounded-xl px-3 text-xs font-semibold tracking-[0.06em] transition hover:brightness-95 ${
       active
-        ? "bg-blue-600 text-white"
-        : "border border-[color:var(--card-border)] bg-[var(--surface)] text-[var(--muted)] hover:text-[var(--foreground)]"
+        ? "border border-[color:var(--utc-to-local-output-border)] bg-[var(--utc-to-local-output-bg)] text-[var(--foreground)]"
+        : "border border-[color:var(--card-border)] bg-[var(--surface-muted)] text-[var(--foreground)]"
     }`;
 
   return (
@@ -624,15 +624,23 @@ export default function K6Generator({ tool }: { tool: ToolItem }) {
             <div className="flex items-center justify-between">
               <ToolBadge>Generated Script</ToolBadge>
               <div className="flex items-center gap-2">
-                <ToolActionButton type="button" onClick={handleCopy} disabled={!activeScript.trim()}>
+                <ToolActionButton type="button" onClick={handleCopy} tone="teal" disabled={!activeScript.trim()}>
                   {isCopied() ? "Copied!" : "Copy"}
                 </ToolActionButton>
                 {scriptTab === "custom" ? (
-                  <ToolActionButton type="button" onClick={() => setCustomScript("")}>
+                  <ToolActionButton
+                    type="button"
+                    onClick={() => setCustomScript("")}
+                    className="border-[color:var(--local-to-utc-output-border)] bg-[var(--local-to-utc-output-bg)]"
+                  >
                     Clear
                   </ToolActionButton>
                 ) : (
-                  <ToolActionButton type="button" onClick={handleClear}>
+                  <ToolActionButton
+                    type="button"
+                    onClick={handleClear}
+                    className="border-[color:var(--local-to-utc-output-border)] bg-[var(--local-to-utc-output-bg)]"
+                  >
                     Clear
                   </ToolActionButton>
                 )}

--- a/src/tools/url.tsx
+++ b/src/tools/url.tsx
@@ -92,6 +92,7 @@ export default function UrlTool({ tool }: { tool: ToolItem }) {
             <ToolActionButton
               type="button"
               onClick={() => handleClear("plain")}
+              className="border-[color:var(--local-to-utc-output-border)] bg-[var(--local-to-utc-output-bg)]"
             >
               {clearState === "plain" ? "Cleared" : "Clear"}
             </ToolActionButton>
@@ -110,6 +111,7 @@ export default function UrlTool({ tool }: { tool: ToolItem }) {
             <ToolActionButton
               type="button"
               onClick={() => copy(encoded, "encoded")}
+              tone="teal"
             >
               {isCopied("encoded") ? "Copied" : "Copy"}
             </ToolActionButton>
@@ -137,6 +139,7 @@ export default function UrlTool({ tool }: { tool: ToolItem }) {
             <ToolActionButton
               type="button"
               onClick={() => handleClear("encoded")}
+              className="border-[color:var(--local-to-utc-output-border)] bg-[var(--local-to-utc-output-bg)]"
             >
               {clearState === "encoded" ? "Cleared" : "Clear"}
             </ToolActionButton>
@@ -155,6 +158,7 @@ export default function UrlTool({ tool }: { tool: ToolItem }) {
             <ToolActionButton
               type="button"
               onClick={() => copy(decoded, "decoded")}
+              tone="teal"
             >
               {isCopied("decoded") ? "Copied" : "Copy"}
             </ToolActionButton>

--- a/src/tools/url.tsx
+++ b/src/tools/url.tsx
@@ -92,7 +92,7 @@ export default function UrlTool({ tool }: { tool: ToolItem }) {
             <ToolActionButton
               type="button"
               onClick={() => handleClear("plain")}
-              className="border-[color:var(--local-to-utc-output-border)] bg-[var(--local-to-utc-output-bg)]"
+              tone="orange"
             >
               {clearState === "plain" ? "Cleared" : "Clear"}
             </ToolActionButton>
@@ -139,7 +139,7 @@ export default function UrlTool({ tool }: { tool: ToolItem }) {
             <ToolActionButton
               type="button"
               onClick={() => handleClear("encoded")}
-              className="border-[color:var(--local-to-utc-output-border)] bg-[var(--local-to-utc-output-bg)]"
+              tone="orange"
             >
               {clearState === "encoded" ? "Cleared" : "Clear"}
             </ToolActionButton>

--- a/src/tools/utc-calculator.tsx
+++ b/src/tools/utc-calculator.tsx
@@ -231,6 +231,24 @@ function nowInZoneInput(timeZone: string) {
   return formatDateTimeInput(getDatePartsInZone(new Date(), timeZone));
 }
 
+function parseUnixTimestampInput(value: string): Date | null {
+  const raw = value.trim();
+  if (!raw || !/^-?\d+$/.test(raw)) {
+    return null;
+  }
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed)) {
+    return null;
+  }
+  const abs = Math.abs(parsed);
+  const ms = abs < 100_000_000_000 ? parsed * 1000 : parsed;
+  const date = new Date(ms);
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+  return date;
+}
+
 function TimeZonePicker({
   value,
   onChange,
@@ -429,11 +447,8 @@ function CurrentTimePanel({
 
   return (
     <ToolCard>
-      <div className="flex items-center justify-between">
+      <div className="flex items-center">
         <ToolBadge>Current Time</ToolBadge>
-        <ToolActionButton type="button" onClick={() => setNowIso(new Date().toISOString())}>
-          Refresh Now
-        </ToolActionButton>
       </div>
       <div className="grid gap-3 md:grid-cols-2">
         <div className="rounded-xl border border-[color:var(--card-border)] bg-[var(--surface-muted)] p-3">
@@ -472,6 +487,10 @@ export default function UtcCalculator({ tool }: { tool: ToolItem }) {
   const [localInput, setLocalInput] = useState(() => nowInZoneInput(browserTimeZone));
   const [localPickerInput, setLocalPickerInput] = useState(() => nowInZoneInput(browserTimeZone));
   const [sourceZone, setSourceZone] = useState(browserTimeZone);
+  const [unixInput, setUnixInput] = useState(() => String(Math.trunc(Date.now() / 1000)));
+  const [unixTargetZone, setUnixTargetZone] = useState(browserTimeZone);
+  const [unixLocalInput, setUnixLocalInput] = useState(() => nowInZoneInput(browserTimeZone));
+  const [unixSourceZone, setUnixSourceZone] = useState(browserTimeZone);
 
   const timeZones = useMemo(() => getTimeZoneList(browserTimeZone), [browserTimeZone]);
   const optionsReferenceDate = useMemo(() => new Date(), []);
@@ -520,6 +539,38 @@ export default function UtcCalculator({ tool }: { tool: ToolItem }) {
     };
   }, [localInput, sourceZone, timeZoneSet]);
 
+  const unixToDate = useMemo(() => {
+    if (!timeZoneSet.has(unixTargetZone) && parseUtcOffsetMinutes(unixTargetZone) === null) {
+      return { error: "Invalid target timezone. Use IANA timezone or UTC offset (e.g. UTC+8)." };
+    }
+    const parsed = parseUnixTimestampInput(unixInput);
+    if (!parsed) {
+      return { error: "Invalid Unix timestamp. Use seconds(10) or milliseconds(13)." };
+    }
+    return {
+      zonedText: formatDateTime(getDatePartsInZone(parsed, unixTargetZone)),
+      iso: parsed.toISOString(),
+      epochSec: String(Math.trunc(parsed.getTime() / 1000)),
+      epochMs: String(parsed.getTime()),
+      offset: getOffsetLabel(unixTargetZone, parsed),
+    };
+  }, [timeZoneSet, unixInput, unixTargetZone]);
+
+  const dateToUnix = useMemo(() => {
+    if (!timeZoneSet.has(unixSourceZone) && parseUtcOffsetMinutes(unixSourceZone) === null) {
+      return { error: "Invalid source timezone. Use IANA timezone or UTC offset (e.g. UTC+8)." };
+    }
+    const utcDate = toUtcDateFromZonedInput(unixLocalInput, unixSourceZone);
+    if (!utcDate) {
+      return { error: "Invalid local input. Use YYYY-MM-DDTHH:mm:ss format." };
+    }
+    return {
+      iso: utcDate.toISOString(),
+      epochSec: String(Math.trunc(utcDate.getTime() / 1000)),
+      epochMs: String(utcDate.getTime()),
+    };
+  }, [timeZoneSet, unixLocalInput, unixSourceZone]);
+
   return (
     <ToolPage>
       <ToolHeader
@@ -531,8 +582,8 @@ export default function UtcCalculator({ tool }: { tool: ToolItem }) {
       <ToolInfoPanel
         icon="T"
         title="UTC Time Calculator"
-        description="현재 브라우저 로컬시간과 UTC를 함께 확인하고, 원하는 타임존으로 시간을 변환할 수 있습니다. 드롭다운을 클릭한 뒤 검색해 선택하거나 UTC+8 같은 오프셋을 직접 입력할 수 있습니다."
-        chips={["현재 로컬 + UTC", "UTC → Local", "Local → UTC"]}
+        description="현재 브라우저 로컬시간과 UTC를 함께 확인하고, 원하는 타임존으로 시간을 변환할 수 있습니다. Unix timestamp(초/밀리초)와 날짜/시간의 양방향 변환도 지원합니다."
+        chips={["현재 로컬 + UTC", "UTC → Local", "Local → UTC", "Unix ↔ DateTime"]}
       />
 
       <CurrentTimePanel browserTimeZone={browserTimeZone} timeZoneOptions={timeZoneOptions} />
@@ -540,9 +591,11 @@ export default function UtcCalculator({ tool }: { tool: ToolItem }) {
       <section className="grid gap-4 lg:grid-cols-2">
         <ToolCard className="lg:order-2">
           <div className="flex items-center justify-between">
-            <ToolBadge>UTC → Local</ToolBadge>
+            <ToolBadge tone="sky">UTC → Local</ToolBadge>
             <ToolActionButton
               type="button"
+              tone="purple"
+              className="cursor-default"
               onClick={() => {
                 setUtcInput(nowUtcInput());
                 setUtcPickerInput(nowUtcPickerInput());
@@ -587,18 +640,20 @@ export default function UtcCalculator({ tool }: { tool: ToolItem }) {
             <p className="text-xs text-[color:var(--error)]">{utcToLocal.error}</p>
           ) : (
             <>
-              <ToolOutput>{utcToLocal.localText}</ToolOutput>
+              <ToolOutput className="border-[color:var(--utc-to-local-output-border)] bg-[var(--utc-to-local-output-bg)] font-semibold">
+                {utcToLocal.localText}
+              </ToolOutput>
               <p className="text-xs text-[var(--muted)]">
                 {targetZone} ({utcToLocal.offset})
               </p>
               <div className="flex flex-wrap gap-2">
-                <ToolActionButton type="button" onClick={() => copy(utcToLocal.localInputText, "utc-local")}>
+                <ToolActionButton type="button" tone="teal" onClick={() => copy(utcToLocal.localInputText, "utc-local")}>
                   {isCopied("utc-local") ? "Copied" : "Copy Local"}
                 </ToolActionButton>
-                <ToolActionButton type="button" onClick={() => copy(utcToLocal.utcIso, "utc-iso")}>
+                <ToolActionButton type="button" tone="teal" onClick={() => copy(utcToLocal.utcIso, "utc-iso")}>
                   {isCopied("utc-iso") ? "Copied" : "Copy UTC ISO"}
                 </ToolActionButton>
-                <ToolActionButton type="button" onClick={() => copy(utcToLocal.epochMs, "utc-epoch")}>
+                <ToolActionButton type="button" tone="teal" onClick={() => copy(utcToLocal.epochMs, "utc-epoch")}>
                   {isCopied("utc-epoch") ? "Copied" : "Copy Epoch"}
                 </ToolActionButton>
               </div>
@@ -608,9 +663,11 @@ export default function UtcCalculator({ tool }: { tool: ToolItem }) {
 
         <ToolCard className="lg:order-1">
           <div className="flex items-center justify-between">
-            <ToolBadge>Local → UTC</ToolBadge>
+            <ToolBadge tone="orange">Local → UTC</ToolBadge>
             <ToolActionButton
               type="button"
+              tone="purple"
+              className="cursor-default"
               onClick={() => {
                 const nowLocal = nowInZoneInput(sourceZone);
                 setLocalInput(nowLocal);
@@ -656,17 +713,125 @@ export default function UtcCalculator({ tool }: { tool: ToolItem }) {
             <p className="text-xs text-[color:var(--error)]">{localToUtc.error}</p>
           ) : (
             <>
-              <ToolOutput>{localToUtc.utcIso}</ToolOutput>
+              <ToolOutput className="border-[color:var(--local-to-utc-output-border)] bg-[var(--local-to-utc-output-bg)] font-semibold">
+                {localToUtc.utcIso}
+              </ToolOutput>
               <p className="text-xs text-[var(--muted)]">Normalized Local: {localToUtc.normalizedLocal}</p>
               <div className="flex flex-wrap gap-2">
-                <ToolActionButton type="button" onClick={() => copy(localToUtc.utcInputText, "local-utc")}>
+                <ToolActionButton type="button" tone="teal" onClick={() => copy(localToUtc.utcInputText, "local-utc")}>
                   {isCopied("local-utc") ? "Copied" : "Copy UTC"}
                 </ToolActionButton>
-                <ToolActionButton type="button" onClick={() => copy(localToUtc.utcIso, "local-iso")}>
+                <ToolActionButton type="button" tone="teal" onClick={() => copy(localToUtc.utcIso, "local-iso")}>
                   {isCopied("local-iso") ? "Copied" : "Copy ISO"}
                 </ToolActionButton>
-                <ToolActionButton type="button" onClick={() => copy(localToUtc.epochMs, "local-epoch")}>
+                <ToolActionButton type="button" tone="teal" onClick={() => copy(localToUtc.epochMs, "local-epoch")}>
                   {isCopied("local-epoch") ? "Copied" : "Copy Epoch"}
+                </ToolActionButton>
+              </div>
+            </>
+          )}
+        </ToolCard>
+      </section>
+
+      <ToolInfoPanel
+        icon="U"
+        title="Unix Timestamp Converter"
+        description="Unix timestamp(초/밀리초)와 날짜/시간을 원하는 타임존 기준으로 상호 변환합니다."
+        chips={["Unix → Date/Time", "Date/Time → Unix", "Seconds / Milliseconds"]}
+      />
+
+      <section className="grid gap-4 lg:grid-cols-2">
+        <ToolCard>
+          <div className="flex items-center justify-between">
+            <ToolBadge tone="teal">Unix → Date/Time</ToolBadge>
+            <ToolActionButton
+              type="button"
+              tone="purple"
+              className="cursor-default"
+              onClick={() => setUnixInput(String(Math.trunc(Date.now() / 1000)))}
+            >
+              Now(Unix)
+            </ToolActionButton>
+          </div>
+          <ToolInput
+            value={unixInput}
+            onChange={(e) => setUnixInput(e.target.value)}
+            placeholder="1710153600 or 1710153600000"
+            className="font-mono"
+          />
+          <TimeZonePicker
+            value={unixTargetZone}
+            onChange={setUnixTargetZone}
+            options={timeZoneOptions}
+            placeholder="Search timezone or type UTC+8"
+          />
+          {"error" in unixToDate ? (
+            <p className="text-xs text-[color:var(--error)]">{unixToDate.error}</p>
+          ) : (
+            <>
+              <ToolOutput className="border-[color:var(--unix-to-date-output-border)] bg-[var(--unix-to-date-output-bg)] font-semibold">
+                {unixToDate.zonedText}
+              </ToolOutput>
+              <p className="text-xs text-[var(--muted)]">
+                {unixTargetZone} ({unixToDate.offset})
+              </p>
+              <div className="flex flex-wrap gap-2">
+                <ToolActionButton type="button" tone="teal" onClick={() => copy(unixToDate.iso, "unix-iso")}>
+                  {isCopied("unix-iso") ? "Copied" : "Copy ISO"}
+                </ToolActionButton>
+                <ToolActionButton type="button" tone="teal" onClick={() => copy(unixToDate.epochSec, "unix-sec")}>
+                  {isCopied("unix-sec") ? "Copied" : "Copy Sec"}
+                </ToolActionButton>
+                <ToolActionButton type="button" tone="teal" onClick={() => copy(unixToDate.epochMs, "unix-ms")}>
+                  {isCopied("unix-ms") ? "Copied" : "Copy Ms"}
+                </ToolActionButton>
+              </div>
+            </>
+          )}
+        </ToolCard>
+
+        <ToolCard>
+          <div className="flex items-center justify-between">
+            <ToolBadge>Date/Time → Unix</ToolBadge>
+            <ToolActionButton
+              type="button"
+              tone="purple"
+              className="cursor-default"
+              onClick={() => setUnixLocalInput(nowInZoneInput(unixSourceZone))}
+            >
+              Now(Local)
+            </ToolActionButton>
+          </div>
+          <ToolInput
+            type="datetime-local"
+            step={1}
+            value={unixLocalInput}
+            onChange={(e) => setUnixLocalInput(e.target.value)}
+            className="pr-9 font-mono"
+          />
+          <TimeZonePicker
+            value={unixSourceZone}
+            onChange={setUnixSourceZone}
+            options={timeZoneOptions}
+            placeholder="Search timezone or type UTC+8"
+          />
+          {"error" in dateToUnix ? (
+            <p className="text-xs text-[color:var(--error)]">{dateToUnix.error}</p>
+          ) : (
+            <>
+              <ToolOutput className="border-[color:var(--date-to-unix-output-border)] bg-[var(--date-to-unix-output-bg)] font-semibold">
+                {dateToUnix.epochSec}
+              </ToolOutput>
+              <p className="text-xs text-[var(--muted)]">Milliseconds: {dateToUnix.epochMs}</p>
+              <div className="flex flex-wrap gap-2">
+                <ToolActionButton type="button" tone="teal" onClick={() => copy(dateToUnix.epochSec, "date-unix-sec")}>
+                  {isCopied("date-unix-sec") ? "Copied" : "Copy Sec"}
+                </ToolActionButton>
+                <ToolActionButton type="button" tone="teal" onClick={() => copy(dateToUnix.epochMs, "date-unix-ms")}>
+                  {isCopied("date-unix-ms") ? "Copied" : "Copy Ms"}
+                </ToolActionButton>
+                <ToolActionButton type="button" tone="teal" onClick={() => copy(dateToUnix.iso, "date-unix-iso")}>
+                  {isCopied("date-unix-iso") ? "Copied" : "Copy ISO"}
                 </ToolActionButton>
               </div>
             </>


### PR DESCRIPTION
## 📝 작업 내용
- UTC & Unix 계산기 기능 확장
- utc-calculator에 Unix Timestamp 변환(Unix→DateTime, DateTime→Unix) 섹션 추가
- Current Time 패널 개선(선택 시간대 표시, 불필요한 Refresh 제거)
- slug를 utc-calculator에서 utc-unix-calculator로 변경
- 테마/렌더링 UX 개선
- 기본 테마를 dark로 변경하고 초기 스크립트로 테마 플래시(새로고침 시 light 깜빡임) 완화
- theme provider 초기화 로직 정리
- 공통 UI 컴포넌트 정비
- ToolBadge/ToolActionButton tone 시스템 확장(blue/teal/orange/purple/red/neutral 등)
- Copy 계열 버튼 teal, Clear 계열 버튼 orange 톤 적용
- 버튼/배지 타이포 및 크기를 본문 스케일에 맞게 조정
- number input 스피너 제거(공통 ToolInput)
- 도구별 UI 일관성 개선
- diff: Left/Right를 Original/Updated로 변경하고 배지 적용
- jsonviewer/java-memory 주요 섹션 라벨에 neutral 배지 적용
- jwt 알고리즘 선택 버튼 스타일 통일
- home 검색 버튼 라벨/톤 조정
- globals/layout/error-boundary 등 전역 스타일/버튼 톤 정리
- 관련 도구 페이지(base64/url/cron/k6/jwt/jsonviewer/java-memory/diff) 버튼 스타일 일관화

## 🔗 관련 이슈

- Closes #

